### PR TITLE
Python3 support: iteritems() -> items()

### DIFF
--- a/cloudshell/snmp/autoload/domain/entity/snmp_entity_base.py
+++ b/cloudshell/snmp/autoload/domain/entity/snmp_entity_base.py
@@ -100,7 +100,7 @@ class BaseEntity(object):
             if not self.vendor_type:
                 return ""
             entity_class = entity_class.replace("'", "")
-            for key, value in ENTITY_VENDOR_TYPE_TO_CLASS_MAP.iteritems():
+            for key, value in ENTITY_VENDOR_TYPE_TO_CLASS_MAP.items():
                 if key.search(self.vendor_type.lower()):
                     entity_class = value
         if ENTITY_TO_CONTAINER_PATTERN.search(self.vendor_type):

--- a/cloudshell/snmp/autoload/domain/if_entity/snmp_if_port_channel_entity.py
+++ b/cloudshell/snmp/autoload/domain/if_entity/snmp_if_port_channel_entity.py
@@ -28,7 +28,7 @@ class SnmpIfPortChannel(SnmpIfEntity):
         for (
             key,
             value,
-        ) in self._port_attributes_snmp_tables.port_channel_ports.iteritems():
+        ) in self._port_attributes_snmp_tables.port_channel_ports.items():
             if str(self.if_index) in value["dot3adAggPortAttachedAggID"]:
                 result.append(key)
         return result


### PR DESCRIPTION
iteritems() doesn't work in python 3.x, so it must be replaced with items()